### PR TITLE
Improving the error log to track what exactly the issue is with regard to the Jira APPFAC-3042

### DIFF
--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
@@ -666,8 +666,8 @@ public class CommonUtil {
                         .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
                 Schema schema = schemaFactory.newSchema(new File(schemaPath));
                 lifecycleSchemaValidator = schema.newValidator();
-            } catch (SAXException e) {
-                log.error("Unable to get a schema validator from the given file path : " + schemaPath);
+            } catch (Exception e) {
+                log.error("Unable to get a schema validator from the given file path : " + schemaPath,e);
             }
         }
         return lifecycleSchemaValidator;


### PR DESCRIPTION
There was an issue reported [1] in Appfactory cloud saying "Unable to get a schema validator from the given file path"

With the existing log we could figure out what is the exact issue. Hence, I have improved the error log trace so that we can get more details with regard to this error. Please merge this with the master repo.

[1] https://wso2.org/jira/browse/APPFAC-3042
