### PR TITLE
REGISTRY-2979 Fix

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
@@ -1423,10 +1423,11 @@ public class GovernanceUtils {
                 if (artifactAttributes != null) {
                     for (String artifactAttribute : artifactAttributes) {
                         String[] parts = artifactAttribute.split(":");
-                        output.addAll(fixExpressionForMultiplePaths(artifact,
-                                expression.replace("@{" + key + ":key}", parts[0]).replace(
-                                        "@{" + key + ":value}", parts[1])
-                        ));
+                        if (parts.length > 1) {
+                            output.addAll(fixExpressionForMultiplePaths(artifact,
+                                    expression.replace("@{" + key + ":key}", parts[0])
+                                            .replace("@{" + key + ":value}", parts[1])));
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
Fixing array out of bound when text field of the options text field is empty. This array out of bound occurs when association are created.