### PR TITLE
Provide a way to get content of content artifacts via governance REST API

### DIFF
--- a/components/governance/org.wso2.carbon.governance.rest.api/src/main/java/org/wso2/carbon/governance/rest/api/internal/ContentArtifactMessageBodyWriter.java
+++ b/components/governance/org.wso2.carbon.governance.rest.api/src/main/java/org/wso2/carbon/governance/rest/api/internal/ContentArtifactMessageBodyWriter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.governance.rest.api.internal;
+
+import org.apache.commons.io.IOUtils;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class ContentArtifactMessageBodyWriter implements MessageBodyWriter<ByteArrayInputStream> {
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return ByteArrayInputStream.class.isAssignableFrom(aClass);
+    }
+
+    @Override
+    public long getSize(ByteArrayInputStream byteArrayInputStream, Class<?> aClass, Type type, Annotation[] annotations,
+                        MediaType mediaType) {
+        return 0;
+    }
+
+    @Override
+    public void writeTo(ByteArrayInputStream byteArrayInputStream, Class<?> aClass, Type type, Annotation[] annotations,
+                        MediaType mediaType, MultivaluedMap<String, Object> stringObjectMultivaluedMap,
+                        OutputStream outputStream) throws IOException, WebApplicationException {
+        IOUtils.copy(byteArrayInputStream, outputStream);
+        byteArrayInputStream.close();
+        outputStream.close();
+    }
+}

--- a/components/governance/org.wso2.carbon.governance.rest.api/src/main/webapp/WEB-INF/beans.xml
+++ b/components/governance/org.wso2.carbon.governance.rest.api/src/main/webapp/WEB-INF/beans.xml
@@ -42,6 +42,7 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
     </jaxrs:serviceBeans>
     <jaxrs:providers>
         <bean class="org.wso2.carbon.governance.rest.api.security.AuthenticationHandler"/>
+        <bean class="org.wso2.carbon.governance.rest.api.internal.ContentArtifactMessageBodyWriter"/>
         <bean class="org.wso2.carbon.governance.rest.api.internal.GenericArtifactMessageBodyWriter"/>
         <bean class="org.wso2.carbon.governance.rest.api.internal.AssetStateMessageBodyWriter"/>
         <bean class="org.wso2.carbon.governance.rest.api.internal.GenericArtifactMessageBodyReader"/>


### PR DESCRIPTION
[1] https://wso2.org/jira/browse/REGISTRY-3124

Added a new URL pattern GET  /governance/<RXT_short_name_s>/UUID/raw

Ex - 
https://localhost:9443/governance/wsdls/790ae5ba-5915-47a7-a8f8-d05e3a1c5827/raw
https://localhost:9443/governance/swaggers/bad65a3d-2e82-4a79-9228-4896ddf3d288/raw

This raw URL pattern only work with content RXT types.
If a request recieved with a generic artifact type server will return a 400-bad request as response.
If the system cannot locate the specified UUID, 404 - not found will be returned.