### PR TITLE
Fix for REGISTRY-3376

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/common/dataobjects/GovernanceArtifactImpl.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/common/dataobjects/GovernanceArtifactImpl.java
@@ -725,7 +725,10 @@ public abstract class GovernanceArtifactImpl implements GovernanceArtifact {
                 if (!destinationPath.equals(path)) {
                     GovernanceArtifact governanceArtifact =
                             GovernanceUtils.retrieveGovernanceArtifactByPath(registry, destinationPath);
-                    governanceArtifacts.add(governanceArtifact);
+                    //The Governance Artifact may not be returned if the user does not have permission to access it
+                    if(governanceArtifact!=null){
+                        governanceArtifacts.add(governanceArtifact);
+                    }
                 }
             }
         } catch (RegistryException e) {
@@ -757,7 +760,10 @@ public abstract class GovernanceArtifactImpl implements GovernanceArtifact {
                 if (!destinationPath.equals(path)) {
                     GovernanceArtifact governanceArtifact =
                             GovernanceUtils.retrieveGovernanceArtifactByPath(registry, destinationPath);
-                    governanceArtifacts.add(governanceArtifact);
+                    //The Governance Artifact may not be returned if the user does not have permission to access it
+                    if(governanceArtifact!=null){
+                        governanceArtifacts.add(governanceArtifact);
+                    }
                 }
             }
         } catch (RegistryException e) {


### PR DESCRIPTION
This PR ensures that the getDependencies and getDependent methods no longer return a mixed set of results containing NULLs. 

Addresses the following issue: [REGISTRY-3376](https://wso2.org/jira/browse/REGISTRY-3376)