### PR TITLE
Fix for REGISTRY-3634

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
@@ -1934,10 +1934,24 @@ public class GovernanceUtils {
 
             List<GovernanceArtifact> propertySearchResults = performAttributeSearch(fields, registry);
 
-            Set<GovernanceArtifact> set  = new TreeSet<>(new Comparator<GovernanceArtifact>() {
-                public int compare(GovernanceArtifact artifact1, GovernanceArtifact artifact2)
-                {
-                    return artifact1.getId().compareTo(artifact2.getId()) ;
+            Set<GovernanceArtifact> set = new TreeSet<>(new Comparator<GovernanceArtifact>() {
+                public int compare(GovernanceArtifact artifact1, GovernanceArtifact artifact2) {
+                    PaginationContext paginationContext = PaginationContext.getInstance();
+                    String sortBy = paginationContext.getSortBy();
+                    try {
+                        switch (paginationContext.getSortOrder()) {
+                            case "ASC":
+                                return artifact1.getAttribute(sortBy).compareTo(artifact2.getAttribute(sortBy));
+                            case "DESC":
+                                return artifact2.getAttribute(sortBy).compareTo(artifact1.getAttribute(sortBy));
+                            default:
+                                return artifact1.getId().compareTo(artifact2.getId());
+                        }
+                    } catch (GovernanceException e) {
+                        log.error("Error when trying to compare the sortBy attributes of the returned artifacts.", e);
+                    }
+
+                    return artifact1.getId().compareTo(artifact2.getId());
                 }
             });
 

--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
@@ -1937,18 +1937,21 @@ public class GovernanceUtils {
             Set<GovernanceArtifact> set = new TreeSet<>(new Comparator<GovernanceArtifact>() {
                 public int compare(GovernanceArtifact artifact1, GovernanceArtifact artifact2) {
                     PaginationContext paginationContext = PaginationContext.getInstance();
-                    String sortBy = paginationContext.getSortBy();
-                    try {
-                        switch (paginationContext.getSortOrder()) {
-                            case "ASC":
-                                return artifact1.getAttribute(sortBy).compareTo(artifact2.getAttribute(sortBy));
-                            case "DESC":
-                                return artifact2.getAttribute(sortBy).compareTo(artifact1.getAttribute(sortBy));
-                            default:
-                                return artifact1.getId().compareTo(artifact2.getId());
+                    if(paginationContext != null) {
+                        String sortBy = paginationContext.getSortBy();
+                        try {
+                            switch (paginationContext.getSortOrder()) {
+                                case "ASC":
+                                    return artifact1.getAttribute(sortBy).compareTo(artifact2.getAttribute(sortBy));
+                                case "DES":
+                                case "DESC":
+                                    return artifact2.getAttribute(sortBy).compareTo(artifact1.getAttribute(sortBy));
+                                default:
+                                    return artifact1.getId().compareTo(artifact2.getId());
+                            }
+                        } catch (GovernanceException e) {
+                            log.error("Error when trying to compare the sortBy attributes of the returned artifacts.", e);
                         }
-                    } catch (GovernanceException e) {
-                        log.error("Error when trying to compare the sortBy attributes of the returned artifacts.", e);
                     }
 
                     return artifact1.getId().compareTo(artifact2.getId());


### PR DESCRIPTION
This PR fixes [REGISRTY-3634](https://wso2.org/jira/browse/REGISTRY-3634)

When attribute search list and property search lists are added to the TreeSet to remove duplicates, assets will be ordered according to the information available in the PaginationContext.