### PR TITLE
REGISTRY-3634 : Fixing issue with unable to sort with date/time attributes

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
@@ -1964,6 +1964,11 @@ public class GovernanceUtils {
                 }
 
                 private int comparison(String value1, String value2, String sortBy) throws GovernanceException {
+                    //If sortBy is equal to a date/time attribute, preserve the order returned from the solr client.
+                    if(sortBy.equals("createdDate") || sortBy.equals("lastUpdatedDate")) {
+                        return 1;
+                    }
+                    //Else if sortBy an attribute
                     if (value1 == null) {
                         throw new GovernanceException("Artifact does not contain the attribute " + sortBy);
                     }


### PR DESCRIPTION
This PR is related to [REGISTRY-3634](https://wso2.org/jira/browse/REGISTRY-3634)

Fixed the issue which is unable to sort when date/time attribute is set as the sortBy value in PaginationContext. 

This is resolved by preserving the order returned by the SolrClient when date/time attribute is involved. 