### PR TITLE
Categorization feature - Adding priority attribute to xsd to order categorization fields in store

### DIFF
--- a/features/extensions/org.wso2.carbon.registry.extensions.server.feature/resources/rxt.xsd
+++ b/features/extensions/org.wso2.carbon.registry.extensions.server.feature/resources/rxt.xsd
@@ -126,6 +126,7 @@
         <xs:attribute name="path" type="xs:boolean"/>
         <xs:attribute name="required" type="xs:boolean"/>
         <xs:attribute name="categorization" type="xs:boolean"/>
+        <xs:attribute name="priority" type="xs:nonNegativeInteger"/>
         <xs:attribute name="type" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:string">

--- a/features/extensions/org.wso2.carbon.registry.extensions.server.feature/resources/service-ui-config.xsd
+++ b/features/extensions/org.wso2.carbon.registry.extensions.server.feature/resources/service-ui-config.xsd
@@ -56,6 +56,7 @@
         <xs:attribute name="path" type="xs:boolean"/>
         <xs:attribute name="required" type="xs:boolean"/>
         <xs:attribute name="categorization" type="xs:boolean"/>
+        <xs:attribute name="priority" type="xs:nonNegativeInteger"/>
         <xs:attribute name="type" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:string">


### PR DESCRIPTION
This PR includes xsd changes to add a priority attribute to field type that is used to order categorization field types in GC store