### PR TITLE
Handle invalid page numbers in params

### DIFF
--- a/components/governance/org.wso2.carbon.governance.generic.ui/src/main/resources/web/generic/list.jsp
+++ b/components/governance/org.wso2.carbon.governance.generic.ui/src/main/resources/web/generic/list.jsp
@@ -155,10 +155,34 @@ td.deprecate-warning {
                 bean = client.listArtifactsByLC(key, lc_name, lc_state, lc_in_out, lc_state_in_out);
             }
         }
+    } catch (NumberFormatException e) {
+        if (filter) {
+%>
+    <script type="text/javascript">
+    CARBON.showErrorDialog("The value for parameter \"page\" is not a number", function() {
+        location.href = "../generic/list.jsp?region=<%=Encode.forUriComponent(region)%>&item=
+        <%=Encode.forUriComponent(item)%><%=Encode.forUriComponent(queryTrailer)%>";
+        return;
+    });
+
+    </script>
+<%
+} else {
+%>
+    <script type="text/javascript">
+    CARBON.showErrorDialog("The value for parameter \"page\" is not a number", function() {
+        location.href = "../admin/index.jsp";
+        return;
+    });
+
+    </script>
+<%
+        }
+        return;
     } catch (Exception e) {
         if (filter) {
 %>
-<script type="text/javascript">
+    <script type="text/javascript">
     CARBON.showErrorDialog("<%=Encode.forJavaScript(e.getMessage())%>", function() {
         location.href = "../generic/list.jsp?region=<%=Encode.forUriComponent(region)%>&item=
         <%=Encode.forUriComponent(item)%><%=Encode.forUriComponent(queryTrailer)%>";

--- a/components/governance/org.wso2.carbon.governance.generic.ui/src/main/resources/web/generic/list_content.jsp
+++ b/components/governance/org.wso2.carbon.governance.generic.ui/src/main/resources/web/generic/list_content.jsp
@@ -142,6 +142,17 @@
             bean = client.listContentArtifactsByLC(mediaType, lc_name, lc_state, lc_in_out, lc_state_in_out);
         }
 
+    } catch (NumberFormatException e) {
+    %>
+    <script type="text/javascript">
+        CARBON.showErrorDialog("The value for parameter \"page\" is not a number", function () {
+            location.href = "../admin/index.jsp";
+            return;
+        });
+
+    </script>
+    <%
+        return;
     } catch (Exception e) {
 
 


### PR DESCRIPTION
Handle invalid page numbers in params separately by catching NumberFormatException. 