### PR TITLE
Property search results after initializing paginationcontext gives search results with some missing values

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/pom.xml
+++ b/components/governance/org.wso2.carbon.governance.api/pom.xml
@@ -124,6 +124,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
@@ -2051,7 +2051,6 @@ public class GovernanceUtils {
             List<GovernanceArtifact> mergeListWithoutDuplicates = new ArrayList<>();
             mergeListWithoutDuplicates.addAll(removeDuplicate);
 
-
             Set<GovernanceArtifact> set = new TreeSet<>(new Comparator<GovernanceArtifact>() {
                 public int compare(GovernanceArtifact artifact1, GovernanceArtifact artifact2) {
                     PaginationContext paginationContext = PaginationContext.getInstance();
@@ -2090,8 +2089,11 @@ public class GovernanceUtils {
                     if (value1 == null) {
                         throw new GovernanceException("Artifact does not contain the attribute " + sortBy);
                     }
-
-                    return value1.compareTo(value2);
+                    int comparisonValue = value1.compareTo(value2);
+                    if (comparisonValue == 0) {
+                        return -1;
+                    }
+                    return comparisonValue;
                 }
             });
 

--- a/components/governance/org.wso2.carbon.governance.api/src/test/java/org/wso2/carbon/governance/api/test/TestBuildSearchCriteria.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/test/java/org/wso2/carbon/governance/api/test/TestBuildSearchCriteria.java
@@ -35,8 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.governance.api.util.GovernanceUtils.findGovernanceArtifacts;
-
 public class TestBuildSearchCriteria extends BaseTestCase {
 
     public void testBuildSearchCriteria() throws Exception {
@@ -52,7 +50,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            findGovernanceArtifacts(
+            GovernanceUtils.findGovernanceArtifacts(
                     "name=SampleURI2&version=1.2" +
                             ".3&tags=123&updater!=admin&author!=admin&mediaType!=admin&associationDest=admin&comments" +
                             "=123",
@@ -77,7 +75,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            findGovernanceArtifacts("name:(SampleURI2 OR SampleURI1)", registry,
+            GovernanceUtils.findGovernanceArtifacts("name:(SampleURI2 OR SampleURI1)", registry,
                                                     governanceArtifactConfiguration.getMediaType());
         } catch (GovernanceException e) {
             assertEquals("Attribute Search Service not Found", e.getMessage());
@@ -99,7 +97,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            findGovernanceArtifacts("taxonomy=(SampleURI2 OR SampleURI1)", registry,
+            GovernanceUtils.findGovernanceArtifacts("taxonomy=(SampleURI2 OR SampleURI1)", registry,
                                                     governanceArtifactConfiguration.getMediaType());
         } catch (GovernanceException e) {
             assertEquals("Attribute Search Service not Found", e.getMessage());
@@ -121,7 +119,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            findGovernanceArtifacts("overview:name=(SampleURI2 OR SampleURI1)", registry,
+            GovernanceUtils.findGovernanceArtifacts("overview:name=(SampleURI2 OR SampleURI1)", registry,
                                                     governanceArtifactConfiguration.getMediaType());
         } catch (GovernanceException e) {
             assertEquals("Attribute Search Service not Found", e.getMessage());
@@ -151,6 +149,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         // Mocking the search method to return both of the resources as a result.
         Mockito.doAnswer(new Answer() {
             private int count = 0;
+
             public Object answer(InvocationOnMock invocation) {
                 if (count == 0) {
                     count++;
@@ -168,7 +167,8 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         List<GovernanceArtifact> governanceArtifacts = GovernanceUtils
                 .findGovernanceArtifacts("name=(SampleURI2 OR " + "SampleURI1)&publisher_roles=(admin)", registry,
                         governanceArtifactConfiguration.getMediaType());
-        assertEquals(2, governanceArtifacts.size());
+        assertEquals("Some governance artifacts are missing in the property search result", 2,
+                governanceArtifacts.size());
     }
 
     /**

--- a/components/governance/org.wso2.carbon.governance.api/src/test/java/org/wso2/carbon/governance/api/test/TestBuildSearchCriteria.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/test/java/org/wso2/carbon/governance/api/test/TestBuildSearchCriteria.java
@@ -15,13 +15,27 @@
  */
 package org.wso2.carbon.governance.api.test;
 
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.wso2.carbon.governance.api.common.dataobjects.GovernanceArtifact;
 import org.wso2.carbon.governance.api.exception.GovernanceException;
 import org.wso2.carbon.governance.api.test.utils.BaseTestCase;
 import org.wso2.carbon.governance.api.util.GovernanceArtifactConfiguration;
 import org.wso2.carbon.governance.api.util.GovernanceConstants;
 import org.wso2.carbon.governance.api.util.GovernanceUtils;
+import org.wso2.carbon.registry.common.AttributeSearchService;
+import org.wso2.carbon.registry.common.ResourceData;
 import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.pagination.PaginationContext;
 import org.wso2.carbon.registry.core.session.UserRegistry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.governance.api.util.GovernanceUtils.findGovernanceArtifacts;
 
 public class TestBuildSearchCriteria extends BaseTestCase {
 
@@ -38,7 +52,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            GovernanceUtils.findGovernanceArtifacts(
+            findGovernanceArtifacts(
                     "name=SampleURI2&version=1.2" +
                             ".3&tags=123&updater!=admin&author!=admin&mediaType!=admin&associationDest=admin&comments" +
                             "=123",
@@ -63,7 +77,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            GovernanceUtils.findGovernanceArtifacts("name:(SampleURI2 OR SampleURI1)", registry,
+            findGovernanceArtifacts("name:(SampleURI2 OR SampleURI1)", registry,
                                                     governanceArtifactConfiguration.getMediaType());
         } catch (GovernanceException e) {
             assertEquals("Attribute Search Service not Found", e.getMessage());
@@ -85,7 +99,7 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            GovernanceUtils.findGovernanceArtifacts("taxonomy=(SampleURI2 OR SampleURI1)", registry,
+            findGovernanceArtifacts("taxonomy=(SampleURI2 OR SampleURI1)", registry,
                                                     governanceArtifactConfiguration.getMediaType());
         } catch (GovernanceException e) {
             assertEquals("Attribute Search Service not Found", e.getMessage());
@@ -107,12 +121,67 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         GovernanceUtils.loadGovernanceArtifacts((UserRegistry) registry);
 
         try {
-            GovernanceUtils.findGovernanceArtifacts("overview:name=(SampleURI2 OR SampleURI1)", registry,
+            findGovernanceArtifacts("overview:name=(SampleURI2 OR SampleURI1)", registry,
                                                     governanceArtifactConfiguration.getMediaType());
         } catch (GovernanceException e) {
             assertEquals("Attribute Search Service not Found", e.getMessage());
             assertNull(e.getCause());
         }
 
+    }
+
+    /**
+     * This test case tests the behavior of search with the property.
+     */
+    @SuppressWarnings("unchecked")
+    public void testBuildSearchCriteriaProperty() throws RegistryException {
+        registry.put("/uri", createResource());
+        registry.put("/uri2", createResource());
+        final GovernanceArtifactConfiguration governanceArtifactConfiguration = GovernanceUtils
+                .getGovernanceArtifactConfiguration(
+                        getStringFromInputStream(this.getClass().getClassLoader().getResourceAsStream("uri.rxt")));
+        governanceArtifactConfiguration.setMediaType(GovernanceConstants.GOVERNANCE_ARTIFACT_CONFIGURATION_MEDIA_TYPE);
+        GovernanceUtils
+                .loadGovernanceArtifacts((UserRegistry) registry, new ArrayList<GovernanceArtifactConfiguration>() {{
+                    add(governanceArtifactConfiguration);
+                }});
+        AttributeSearchService attributeSearchService = Mockito.mock(AttributeSearchService.class);
+        PaginationContext.init(0, 10, "ASC", "nameAttribute", 100);
+
+        // Mocking the search method to return both of the resources as a result.
+        Mockito.doAnswer(new Answer() {
+            private int count = 0;
+            public Object answer(InvocationOnMock invocation) {
+                if (count == 0) {
+                    count++;
+                    return new ResourceData[0];
+                } else {
+                    ResourceData resourceData = new ResourceData();
+                    resourceData.setResourcePath("/_system/governance/uri");
+                    ResourceData resourceDataCopy = new ResourceData();
+                    resourceDataCopy.setResourcePath("/_system/governance/uri2");
+                    return new ResourceData[] { resourceData, resourceDataCopy };
+                }
+            }
+        }).when(attributeSearchService).search(Mockito.any(Map.class));
+        GovernanceUtils.setAttributeSearchService(attributeSearchService);
+        List<GovernanceArtifact> governanceArtifacts = GovernanceUtils
+                .findGovernanceArtifacts("name=(SampleURI2 OR " + "SampleURI1)&publisher_roles=(admin)", registry,
+                        governanceArtifactConfiguration.getMediaType());
+        assertEquals(2, governanceArtifacts.size());
+    }
+
+    /**
+     * To create a registry resource for testing purpose.
+     *
+     * @return Resource.
+     * @throws RegistryException Registry Exception.
+     */
+    private Resource createResource() throws RegistryException {
+        Resource resource = registry.newResource();
+        resource.setMediaType(GovernanceConstants.GOVERNANCE_ARTIFACT_CONFIGURATION_MEDIA_TYPE);
+        resource.setContentStream(this.getClass().getClassLoader().getResourceAsStream("uri.rxt"));
+        resource.setProperty("publisher_roles", "admin");
+        return resource;
     }
 }

--- a/components/governance/org.wso2.carbon.governance.api/src/test/java/org/wso2/carbon/governance/api/test/TestBuildSearchCriteria.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/test/java/org/wso2/carbon/governance/api/test/TestBuildSearchCriteria.java
@@ -149,7 +149,6 @@ public class TestBuildSearchCriteria extends BaseTestCase {
         // Mocking the search method to return both of the resources as a result.
         Mockito.doAnswer(new Answer() {
             private int count = 0;
-
             public Object answer(InvocationOnMock invocation) {
                 if (count == 0) {
                     count++;

--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
@@ -572,8 +572,11 @@ public class CommonUtil {
         parameters.put("rightPropertyValue", name);
         parameters.put("rightOp", "eq");
         AttributeSearchService searchService = LifeCycleServiceHolder.getInstance().getAttributeSearchService();
-        ResourceData[] resourceData = searchService.search(parameters);
-        return resourceData.length != 0;
+        if (searchService != null) {
+            ResourceData[] resourceData = searchService.search(parameters);
+            return resourceData.length != 0;
+        }
+        return false;
     }
 
 


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/carbon-governance/issues/297

## Goals
This PR will fix the issue of which property search does not return all the relevant values, after initiating pagination context.

## Approach
Whenever the comparision, gives the value as 0, instead of that returning that we return a negative value.

## User stories
N/A

## Release note
 Fixes the issue of which property search does not return all the relevant values, after initiating pagination context.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
    Added a unit test case
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A