### PR TITLE
Fix: Governance REST API does not return correct/meaningful error messages when adding the same artifact multiple times - REGISTRY-3936

### DIFF
--- a/components/governance/org.wso2.carbon.governance.rest.api/src/main/java/org/wso2/carbon/governance/rest/api/Asset.java
+++ b/components/governance/org.wso2.carbon.governance.rest.api/src/main/java/org/wso2/carbon/governance/rest/api/Asset.java
@@ -635,6 +635,11 @@ public class Asset {
                     return Response.created(link).build();
                 } catch (MalformedURLException | URISyntaxException e) {
                     throw new GovernanceException(e);
+                } catch (GovernanceException e) {
+                    if (e.getMessage().contains("already exists at")) {
+                        String message = e.getMessage().split("\\.", 2)[1].replaceAll("^\\s+", "");
+                        return Response.status(Response.Status.CONFLICT).entity(message).build();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
Fixing Governance REST API does not return correct/meaningful error messages when adding the same artifact multiple times - REGISTRY-3936

## Goals
This will fix error - Governance REST API does not return correct/meaningful error messages when adding the same artifact multiple times - REGISTRY-3936

## Approach
Change the code in governance war file



## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests

 - Integration tests
   > https://github.com/wso2/product-greg/pull/883

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs


## Migrations (if applicable)
N/A

## Test environment
JDK 1.7

  