### PR TITLE
Add null check

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/util/GovernanceUtils.java
@@ -2193,7 +2193,13 @@ public class GovernanceUtils {
 
             for (ResourceData result : results) {
                 GovernanceArtifact governanceArtifact = null;
-                String path = result.getResourcePath().substring(RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH.length());
+                int registryBasePathLength = RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH.length();
+                if (result == null
+                        || result.getResourcePath() == null
+                        || result.getResourcePath().length() < registryBasePathLength) {
+                    continue;
+                }
+                String path = result.getResourcePath().substring(registryBasePathLength);
                 try {
                     governanceArtifact = retrieveGovernanceArtifactByPath(registry, path);
                 } catch (GovernanceException e) {


### PR DESCRIPTION
## Purpose
> When the result contains a null resource path we get NPE and it's not handled. Either we should ignore the result or implement logic to handle the result with resourcePath == null. In this PR we are ignoring the result. Suggest if there is a better approach. 