### PR TITLE
Improve governance to provide uuid when creating artifacts

### DIFF
--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/common/GovernanceArtifactManager.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/common/GovernanceArtifactManager.java
@@ -153,6 +153,18 @@ public class GovernanceArtifactManager {
     }
 
     /**
+     * Creates a new artifact from the given qualified name.
+     *
+     * @param uuid the UUID of the artifact.
+     * @return the artifact added.
+     * @throws GovernanceException if the operation failed.
+     */
+    public GovernanceArtifact newGovernanceArtifact(String uuid) throws GovernanceException {
+        List<String> uniqueAttributes = GovernanceUtils.getUniqueAttributesNames(registry, mediaType);
+        return GovernanceArtifactImpl.create(registry, uuid, uniqueAttributes);
+    }
+
+    /**
      * Creates a new artifact from the given content.
      *
      * @param content the artifact content.

--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/generic/GenericArtifactManager.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/generic/GenericArtifactManager.java
@@ -130,6 +130,20 @@ public class GenericArtifactManager {
     }
 
     /**
+     * Creates a new artifact from the given qualified name and uuid.
+     * @param qName the qualified name of this artifact.
+     * @param uuid the uuid of this artifact.
+     * @return the artifact added.
+     * @throws GovernanceException if the operation failed.
+     */
+    public GenericArtifact newGovernanceArtifact(QName qName, String uuid) throws GovernanceException {
+        GenericArtifactImpl genericArtifact =
+                new GenericArtifactImpl(manager.newGovernanceArtifact(uuid), mediaType) {};
+        genericArtifact.setQName(qName);
+        return genericArtifact;
+    }
+
+    /**
      * Creates a new artifact from the given qualified name.
      *
      * @param qName the qualified name of this artifact.

--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/generic/dataobjects/GenericArtifactImpl.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/generic/dataobjects/GenericArtifactImpl.java
@@ -201,8 +201,6 @@ public class GenericArtifactImpl extends GovernanceArtifactImpl implements Gener
      * Method to set the qualified name of this artifact.
      *
      * @param qName the qualified name.
-     *
-     * @throws GovernanceException if the operation failed.
      */
     public void setQName(QName qName) {
         // the path will be synced with the qualified name

--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/policies/dataobjects/PolicyImpl.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/policies/dataobjects/PolicyImpl.java
@@ -46,7 +46,6 @@ public class PolicyImpl extends GovernanceArtifactImpl implements Policy {
      * Constructor accepting resource path, identifier and a registry instance.
      * This constructor should be used only when the policy already saved in the registry.
      *
-     * @param path     the resource path.
      * @param id       the resource identifier.
      * @param registry the registry instance.
      *

--- a/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/schema/dataobjects/SchemaImpl.java
+++ b/components/governance/org.wso2.carbon.governance.api/src/main/java/org/wso2/carbon/governance/api/schema/dataobjects/SchemaImpl.java
@@ -50,7 +50,6 @@ public class SchemaImpl extends GovernanceArtifactImpl implements Schema {
      * Constructor accepting resource path, identifier and a registry instance.
      * This constructor should be used only when the wsdl already saved in the registry.
      *
-     * @param path     the resource path.
      * @param id       the resource identifier.
      * @param registry the registry instance.
      *


### PR DESCRIPTION
## Purpose
> Improve governance to provide uuid when creating artifacts. When creating an API, API UUID is generated from carbon-governance hence API Governance cannot be executed against APIs when Creating the APIs

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes